### PR TITLE
Change attribution from forecast.io to Dark Sky

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
 <div id="footer">
   Made by <a href="http://www.tikaro.net">tikaro</a>
   to help plan <a href="http://www.coworkout.com">coworkout</a>.
-  Powered by <a href="http://forecast.io/">forecast.io</a>
+  Powered by <a href="https://darksky.net/poweredby/.">Dark Sky</a>
 </div>
 </body>
 </html>


### PR DESCRIPTION
This changes the attribution at the foot of the page from "Powered by forecast.io" to "Powered by Dark Sky", at their request.

You should be able to load the page, then check that the attribution at the bottom looks good and clicks through to a working page.